### PR TITLE
Do not display error when storage type is not set

### DIFF
--- a/cacheModule.js
+++ b/cacheModule.js
@@ -198,7 +198,7 @@ function cacheModule(config){
           cache = JSON.parse(db) || cache;
         } catch (err) { /* Do nothing */ }
       }
-      else{
+      else if(config.storage !== 'memory'){
         log(true, 'Browser storage is not supported by this browser. Defaulting to an in-memory cache.');
       }
     }

--- a/cacheModule.js
+++ b/cacheModule.js
@@ -198,7 +198,7 @@ function cacheModule(config){
           cache = JSON.parse(db) || cache;
         } catch (err) { /* Do nothing */ }
       }
-      else if(config.storage !== 'memory'){
+      else if(storageType){
         log(true, 'Browser storage is not supported by this browser. Defaulting to an in-memory cache.');
       }
     }


### PR DESCRIPTION
Currently if we want to use the `in-memory` cache as opposed to `sessionStorage` or `localStorage` this module drops an error like console message relating to the storage engine not being supported when in fact this is deliberate.

This PR basically only shows the error if the storage configuration option is not set to `memory`